### PR TITLE
add throttle: 1 to authorized_key task in create_and_authorize_keypairs

### DIFF
--- a/roles/create_and_authorize_keypairs/tasks/main.yml
+++ b/roles/create_and_authorize_keypairs/tasks/main.yml
@@ -57,6 +57,7 @@
       vars:
         ssh_user: "{{ params.remote_user | default(hostvars['playbook-facts'].options.remote_user) }}"
       delegate_to: "{{ item }}"
+      throttle: 1
 
   vars:
     ssh_keytype: "{{ params.ssh_keytype | default(hostvars['localhost-facts'].options.ssh_keytype) }}"


### PR DESCRIPTION
prevent to processes from each adding a line to the same file concurrently